### PR TITLE
fix: fix ifThenElseMapper for fields in arrays

### DIFF
--- a/packages/vue-json-form/src/Mappers/ifThenElseMapper.ts
+++ b/packages/vue-json-form/src/Mappers/ifThenElseMapper.ts
@@ -267,9 +267,6 @@ export class IfThenElseMapper extends MapperWithData {
                     );
                 }
             }
-            conditions = conditions.concat(
-                this.addRequiredConditions(ifJson, conditions, scope)
-            );
         } else if ('items' in ifJson) {
             // Handle array items: parse the item schema
             const newScope = scope + '/items';
@@ -281,10 +278,10 @@ export class IfThenElseMapper extends MapperWithData {
                     this.parseConditions(ifJson.items, newScope)
                 );
             }
-        } else {
-            // Handle simple if blocks that only specify required fields
-            conditions = this.addRequiredConditions(ifJson, conditions, scope);
         }
+        conditions = conditions.concat(
+            this.addRequiredConditions(ifJson, conditions, scope)
+        );
 
         return conditions;
     }
@@ -403,7 +400,10 @@ export class IfThenElseMapper extends MapperWithData {
         }
         // Iterate up the scope hierarchy in steps of 2 (property levels)
         for (let i = -2; this.scope.split('/').length + i >= 0; i -= 2) {
-            let parentAllOfPath = sliceScope(this.scope, i) + '/' + 'allOf';
+            let parentAllOfPath =
+                sliceScope(this.scope, i).replace(/\/properties$/, '') +
+                '/' +
+                'allOf';
             parentAllOfPath = cleanScope(parentAllOfPath);
             conditionsAndResults = conditionsAndResults.concat(
                 this.getConditionsAndResultsFromAllOf(

--- a/packages/vue-json-form/tests/unit/Mappers/ifThenElseMapper.test.ts
+++ b/packages/vue-json-form/tests/unit/Mappers/ifThenElseMapper.test.ts
@@ -1547,4 +1547,105 @@ describe('IfThenElseMapper', () => {
         result = await mapper.map(initialJson, ui, data);
         expect(result!.jsonElement.title).toBeUndefined();
     });
+
+    it('required-field is required when shown (nested in array items based on boolean condition)', async () => {
+        const fieldScope =
+            '/properties/questionnaire-2/properties/list/items/properties/required-field';
+        const savePath =
+            '/properties/questionnaire-2/properties/list.vjf_array-item_66a10f6e-e43f-4de8-be8d-e93140a4aab2/properties/required-field';
+
+        const jsonSchema: JSONSchema = {
+            title: 'Fragebogen Wizard',
+            type: 'object',
+            properties: {
+                'questionnaire-2': {
+                    title: 'questionnaire 2',
+                    type: 'object',
+                    allOf: [
+                        {
+                            if: {
+                                properties: {
+                                    enabled: {
+                                        const: true,
+                                    },
+                                },
+                                required: ['enabled'],
+                            },
+                            then: {
+                                properties: {
+                                    list: {
+                                        items: {
+                                            properties: {
+                                                'required-field': {
+                                                    minLength: 1,
+                                                },
+                                            },
+                                            required: ['required-field'],
+                                        },
+                                    },
+                                },
+                                required: ['list'],
+                            },
+                        },
+                    ],
+                    properties: {
+                        enabled: {
+                            title: 'enabled',
+                            type: 'boolean',
+                        },
+                        list: {
+                            title: 'list',
+                            type: 'array',
+                            items: {
+                                type: 'object',
+                                properties: {
+                                    'required-field': {
+                                        title: 'required-field',
+                                        type: 'string',
+                                        minLength: 1,
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        const uiSchema = makeLayout();
+        const ui = makeControl(fieldScope);
+        const initialJson: JSONSchema = {};
+
+        mapper.registerSchemata(
+            jsonSchema,
+            uiSchema,
+            fieldScope,
+            savePath,
+            initialJson,
+            ui
+        );
+
+        // Test case 1: enabled is true - required-field should be required
+        let data: Record<string, any> = {
+            '/properties/questionnaire-2/properties/enabled': true,
+        };
+        let result = await mapper.map(initialJson, ui, data);
+        expect(result).not.toBeNull();
+        expect(result!.uiElement.options?.forceRequired).toBe(true);
+        expect(result!.jsonElement.minLength).toBe(1);
+
+        // Test case 2: enabled is false - required-field should not be required
+        data = {
+            '/properties/questionnaire-2/properties/enabled': false,
+        };
+        result = await mapper.map(initialJson, ui, data);
+        expect(result).not.toBeNull();
+        expect(result!.uiElement.options?.forceRequired).not.toBe(true);
+
+        // Test case 3: enabled is undefined/missing - required-field should not be required
+        data = {};
+        result = await mapper.map(initialJson, ui, data);
+        expect(result).not.toBeNull();
+        expect(result!.uiElement.options?.forceRequired).not.toBe(true);
+    });
 });

--- a/packages/vue-json-form/tests/unit/Mappers/ifThenElseMapper.test.ts
+++ b/packages/vue-json-form/tests/unit/Mappers/ifThenElseMapper.test.ts
@@ -1548,6 +1548,252 @@ describe('IfThenElseMapper', () => {
         expect(result!.jsonElement.title).toBeUndefined();
     });
 
+    it('required-field is required when shown (double-nested in array items, allOf at parent object)', async () => {
+        const outerArrayItemId =
+            'vjf_array-item_66a10f6e-e43f-4de8-be8d-e93140a4aab2';
+        const innerArrayItemId =
+            'vjf_array-item_77b20f7f-f543-4de8-be8d-f04251b5bc3d';
+
+        const fieldScope =
+            '/properties/questionnaire-2/properties/list/items/properties/inner-obj/properties/inner-list/items/properties/required-field';
+        const savePath =
+            `/properties/questionnaire-2/properties/list.${outerArrayItemId}/properties/inner-obj/properties/inner-list.${innerArrayItemId}/properties/required-field`;
+
+        const jsonSchema: JSONSchema = {
+            type: 'object',
+            properties: {
+                'questionnaire-2': {
+                    type: 'object',
+                    allOf: [
+                        {
+                            if: {
+                                properties: {
+                                    enabled: {
+                                        const: true,
+                                    },
+                                },
+                                required: ['enabled'],
+                            },
+                            then: {
+                                properties: {
+                                    list: {
+                                        items: {
+                                            properties: {
+                                                'inner-obj': {
+                                                    properties: {
+                                                        'inner-list': {
+                                                            items: {
+                                                                properties: {
+                                                                    'required-field':
+                                                                        {
+                                                                            minLength: 1,
+                                                                        },
+                                                                },
+                                                                required: [
+                                                                    'required-field',
+                                                                ],
+                                                            },
+                                                        },
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    ],
+                    properties: {
+                        enabled: {
+                            type: 'boolean',
+                        },
+                        list: {
+                            type: 'array',
+                            items: {
+                                type: 'object',
+                                properties: {
+                                    'inner-obj': {
+                                        type: 'object',
+                                        properties: {
+                                            'inner-list': {
+                                                type: 'array',
+                                                items: {
+                                                    type: 'object',
+                                                    properties: {
+                                                        'required-field': {
+                                                            type: 'string',
+                                                            minLength: 1,
+                                                        },
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        const uiSchema = makeLayout();
+        const ui = makeControl(fieldScope);
+        const initialJson: JSONSchema = {};
+
+        mapper.registerSchemata(
+            jsonSchema,
+            uiSchema,
+            fieldScope,
+            savePath,
+            initialJson,
+            ui
+        );
+
+        // Test case 1: enabled is true - required-field should be required
+        let data: Record<string, any> = {
+            '/properties/questionnaire-2/properties/enabled': true,
+        };
+        let result = await mapper.map(initialJson, ui, data);
+        expect(result).not.toBeNull();
+        expect(result!.uiElement.options?.forceRequired).toBe(true);
+        expect(result!.jsonElement.minLength).toBe(1);
+
+        // Test case 2: enabled is false - required-field should not be required
+        data = {
+            '/properties/questionnaire-2/properties/enabled': false,
+        };
+        result = await mapper.map(initialJson, ui, data);
+        expect(result).not.toBeNull();
+        expect(result!.uiElement.options?.forceRequired).not.toBe(true);
+
+        // Test case 3: enabled is undefined/missing - required-field should not be required
+        data = {};
+        result = await mapper.map(initialJson, ui, data);
+        expect(result).not.toBeNull();
+        expect(result!.uiElement.options?.forceRequired).not.toBe(true);
+    });
+
+    it('required-field is required when shown (double-nested in array items, allOf at root)', async () => {
+        const outerArrayItemId =
+            'vjf_array-item_66a10f6e-e43f-4de8-be8d-e93140a4aab2';
+        const innerArrayItemId =
+            'vjf_array-item_77b20f7f-f543-4de8-be8d-f04251b5bc3d';
+
+        const fieldScope =
+            '/properties/list/items/properties/inner-obj/properties/inner-list/items/properties/required-field';
+        const savePath =
+            `/properties/list.${outerArrayItemId}/properties/inner-obj/properties/inner-list.${innerArrayItemId}/properties/required-field`;
+
+        const jsonSchema: JSONSchema = {
+            type: 'object',
+            allOf: [
+                {
+                    if: {
+                        properties: {
+                            enabled: {
+                                const: true,
+                            },
+                        },
+                        required: ['enabled'],
+                    },
+                    then: {
+                        properties: {
+                            list: {
+                                items: {
+                                    properties: {
+                                        'inner-obj': {
+                                            properties: {
+                                                'inner-list': {
+                                                    items: {
+                                                        properties: {
+                                                            'required-field': {
+                                                                minLength: 1,
+                                                            },
+                                                        },
+                                                        required: [
+                                                            'required-field',
+                                                        ],
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            ],
+            properties: {
+                enabled: {
+                    type: 'boolean',
+                },
+                list: {
+                    type: 'array',
+                    items: {
+                        type: 'object',
+                        properties: {
+                            'inner-obj': {
+                                type: 'object',
+                                properties: {
+                                    'inner-list': {
+                                        type: 'array',
+                                        items: {
+                                            type: 'object',
+                                            properties: {
+                                                'required-field': {
+                                                    type: 'string',
+                                                    minLength: 1,
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        const uiSchema = makeLayout();
+        const ui = makeControl(fieldScope);
+        const initialJson: JSONSchema = {};
+
+        mapper.registerSchemata(
+            jsonSchema,
+            uiSchema,
+            fieldScope,
+            savePath,
+            initialJson,
+            ui
+        );
+
+        // Test case 1: enabled is true - required-field should be required
+        let data: Record<string, any> = {
+            '/properties/enabled': true,
+        };
+        let result = await mapper.map(initialJson, ui, data);
+        expect(result).not.toBeNull();
+        expect(result!.uiElement.options?.forceRequired).toBe(true);
+        expect(result!.jsonElement.minLength).toBe(1);
+
+        // Test case 2: enabled is false - required-field should not be required
+        data = {
+            '/properties/enabled': false,
+        };
+        result = await mapper.map(initialJson, ui, data);
+        expect(result).not.toBeNull();
+        expect(result!.uiElement.options?.forceRequired).not.toBe(true);
+
+        // Test case 3: enabled is undefined/missing - required-field should not be required
+        data = {};
+        result = await mapper.map(initialJson, ui, data);
+        expect(result).not.toBeNull();
+        expect(result!.uiElement.options?.forceRequired).not.toBe(true);
+    });
+
     it('required-field is required when shown (nested in array items based on boolean condition)', async () => {
         const fieldScope =
             '/properties/questionnaire-2/properties/list/items/properties/required-field';


### PR DESCRIPTION
Fixes `IfThenElseMapper` behavior for controls whose scope is nested under array `items`, ensuring `allOf`-based `if/then/else` rules (including conditional `required`) are correctly discovered and applied for fields inside array items.

## Changes Made

- Fix parent `allOf` path resolution when walking up the scope hierarchy, especially for scopes that include `/items/...`.
- Ensure `required` conditions from `if` blocks are collected consistently (including when traversing `items` schemas).
- Add unit tests covering conditional required behavior for fields nested under array `items` at various depths:
  - Single array nesting: `obj → array → obj field` with `allOf` at parent object level
  - Double array nesting: `obj → array → obj → array → obj field` with `allOf` at parent object level
  - Double array nesting: `obj → array → obj → array → obj field` with `allOf` at root schema level

<!-- START COPILOT CODING AGENT TIPS -->
---

⌨️ Start Copilot coding agent tasks without leaving your editor — available in [VS Code](https://gh.io/cca-vs-code-docs), [Visual Studio](https://gh.io/cca-visual-studio-docs), [JetBrains IDEs](https://gh.io/cca-jetbrains-docs) and [Eclipse](https://gh.io/cca-eclipse-docs).
