### PR TITLE
refactor: migrate from vuedraggable to vue-draggable-plus

### DIFF
--- a/packages/vue-json-form/package.json
+++ b/packages/vue-json-form/package.json
@@ -20,7 +20,7 @@
         "uuid": "^14.0.0",
         "vue": "^3.5.33",
         "vue-component-type-helpers": "^3.2.7",
-        "vuedraggable": "^4.1.0"
+        "vue-draggable-plus": "^0.6.1"
     },
     "devDependencies": {
         "@axe-core/playwright": "^4.11.2",

--- a/packages/vue-json-form/src/components/Array/ArrayControl.vue
+++ b/packages/vue-json-form/src/components/Array/ArrayControl.vue
@@ -14,7 +14,7 @@ import {
     isArrayItemKey,
     VJF_ARRAY_ITEM_PREFIX,
 } from '@/Commons.ts';
-import draggable from 'vuedraggable/src/vuedraggable';
+import { VueDraggable } from 'vue-draggable-plus';
 import {
     ref,
     nextTick,
@@ -53,7 +53,7 @@ const languageProvider = inject(languageProviderKey);
 const id = controlID(savePath);
 const required = getComputedRequired(layoutElement);
 
-function addField(skipFocus = false, value?: any) {
+function addField(skipFocus = false, value?: unknown) {
     const genId = VJF_ARRAY_ITEM_PREFIX + generateUUID();
     if (!jsonSchema.value) {
         throw new Error('jsonSchema is unexpectedly undefined');
@@ -241,34 +241,30 @@ onBeforeMount(initArray);
             :id="id"
             class="vjf_array"
         >
-            <draggable
+            <VueDraggable
                 key="draggable"
                 v-model="formData[savePath]"
                 class="list-group"
                 handle=".handle"
-                :item-key="(elemId: string) => elemId"
                 v-bind="dragOptions"
-                :component-data="{
-                    tag: 'div',
-                    type: 'transition-group',
-                    name: !drag ? 'flip-list' : null,
-                }"
                 @start="drag = true"
                 @end="drag = false"
             >
-                <template #item="{ element, index }">
-                    <div :key="element" class="draggable-array-item">
-                        <ArrayItem
-                            :scope="layoutElement.scope"
-                            :base-save-path="savePath"
-                            :index="index"
-                            :item-i-d="element"
-                            :allow-remove="allowRemoveField"
-                            @delete="deleteItemWithID"
-                        />
-                    </div>
-                </template>
-            </draggable>
+                <div
+                    v-for="(element, index) in formData[savePath]"
+                    :key="element"
+                    class="draggable-array-item"
+                >
+                    <ArrayItem
+                        :scope="layoutElement.scope"
+                        :base-save-path="savePath"
+                        :index="index as number"
+                        :item-i-d="element"
+                        :allow-remove="allowRemoveField"
+                        @delete="deleteItemWithID"
+                    />
+                </div>
+            </VueDraggable>
 
             <array-button
                 variant="outline-primary"
@@ -329,14 +325,6 @@ onBeforeMount(initArray);
 .vjf_label_wrapper {
     display: flex;
     align-items: center;
-}
-
-.flip-list-move {
-    transition: transform 0.5s;
-}
-
-.no-move {
-    transition: transform 0s;
 }
 
 .ghost {

--- a/yarn.lock
+++ b/yarn.lock
@@ -926,10 +926,10 @@ __metadata:
     vitest: "npm:^4.1.5"
     vue: "npm:^3.5.33"
     vue-component-type-helpers: "npm:^3.2.7"
+    vue-draggable-plus: "npm:^0.6.1"
     vue-eslint-parser: "npm:^10.4.0"
     vue-router: "npm:^5.0.6"
     vue-tsc: "npm:^3.2.7"
-    vuedraggable: "npm:^4.1.0"
   languageName: unknown
   linkType: soft
 
@@ -3085,6 +3085,13 @@ __metadata:
   dependencies:
     htmlparser2: "npm:^10.1"
   checksum: 10/fba65c1b612f60cba07af2bb22791997f02b6774a2b68f16a40cb73e92b5f7086684fa6a947b5a24d200aae3607236eb24bfa3f2c56c40cd0e5209baf50bb12a
+  languageName: node
+  linkType: hard
+
+"@types/sortablejs@npm:^1.15.8":
+  version: 1.15.9
+  resolution: "@types/sortablejs@npm:1.15.9"
+  checksum: 10/9e0d6ef1cdcd30acab7af74cab5cbf56685e2de47c6f254357f7dde2626e9b49b8668c43f92761202cf4e10f2e3fd3d7baa6a83a39c3d342fc45ce66e87bd5aa
   languageName: node
   linkType: hard
 
@@ -11846,13 +11853,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sortablejs@npm:1.14.0":
-  version: 1.14.0
-  resolution: "sortablejs@npm:1.14.0"
-  checksum: 10/434e0caaabfac2b4f48e102cc40e12fd0af7dc99f14838005e6429e92cc190f0ccfb48b0cb8deed8a9b808543f926e2aad26aa89277ee036e5b4ee959ae47f9e
-  languageName: node
-  linkType: hard
-
 "source-map-js@npm:>=0.6.2 <2.0.0, source-map-js@npm:^1.2.1":
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
@@ -13621,6 +13621,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vue-draggable-plus@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "vue-draggable-plus@npm:0.6.1"
+  dependencies:
+    "@types/sortablejs": "npm:^1.15.8"
+  peerDependencies:
+    "@types/sortablejs": ^1.15.0
+  peerDependenciesMeta:
+    "@vue/composition-api":
+      optional: true
+  checksum: 10/0de0029db906bece663b88c7df4dc817c34a1c77618ec4b0049f7a112b68768dba789a6226fc5fddee84bee43ec1a74b7071f0fa61fcc8dc9783f1eed2497ac7
+  languageName: node
+  linkType: hard
+
 "vue-eslint-parser@npm:^10.4.0":
   version: 10.4.0
   resolution: "vue-eslint-parser@npm:10.4.0"
@@ -13757,17 +13771,6 @@ __metadata:
     typescript:
       optional: true
   checksum: 10/71224766c803c6b515402b8a32f53a21e96e170d4eb37b5c28b58e494152908ef7b9a5915c56a6c0d2f9c9420678028412e6f82b71c21a678f9f5491c2fdfbb7
-  languageName: node
-  linkType: hard
-
-"vuedraggable@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "vuedraggable@npm:4.1.0"
-  dependencies:
-    sortablejs: "npm:1.14.0"
-  peerDependencies:
-    vue: ^3.0.1
-  checksum: 10/87d4faba83ea27c0c262fcdbe7bc9791560079096a5a9d1dc191ebfe0a00f8324d33ebc15272c4067ddc32b1681534d17acafbe73d18c4cb2a8d99f19d86e74b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Replace the unmaintained vuedraggable@4 with vue-draggable-plus@0.6.1. Update ArrayControl.vue to use the VueDraggable component API:
- Change import to { VueDraggable } from 'vue-draggable-plus'
- Replace #item slot pattern with v-for inside <VueDraggable>
- Remove item-key and component-data props (not supported)